### PR TITLE
feat: add icon and badge for notification

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ hexo.on('generateAfter', async function (post) {
         'date_published': newPost.date.format('L'),
         'summary': util.stripHTML(newPost.excerpt),
         'url': newPost.permalink,
+        'icon': util.full_url_for('/assets/images/favicon.ico'),
+        'badge': util.full_url_for('/assets/images/favicon.ico'),
         'tags': newPost.tags.data.map(function (v) { return v.name }),
         'categories': newPost.categories.data.map(function (v) { return v.name })
     }


### PR DESCRIPTION
Missing icon and badge make notification display is so ugly. Add icon and badge as site's favicon.